### PR TITLE
Fixed issue in heatmap.2 that made plotting large heatmaps very slow

### DIFF
--- a/R/heatmap.2.R
+++ b/R/heatmap.2.R
@@ -225,15 +225,9 @@ heatmap.2 <- function (x,
       if(nr != length(rowInd))
         stop("row dendrogram ordering gave index of wrong length")
     }
-  else if(!isTRUE(Rowv))
-    {
-      rowInd <- nr:1
-      ddr <- as.dendrogram(hclust(dist(diag(nr))))
-    }
   else
     {
       rowInd <- nr:1
-      ddr <- as.dendrogram(Rowv)
     }
 
   if(inherits(Colv, "dendrogram"))
@@ -277,15 +271,9 @@ heatmap.2 <- function (x,
       if(nc != length(colInd))
         stop("column dendrogram ordering gave index of wrong length")
     }
-  else if(!isTRUE(Colv))
-    {
-      colInd <- 1:nc
-      ddc <- as.dendrogram(hclust(dist(diag(nc))))
-    }
   else
     {
       colInd <- 1:nc
-      ddc <- as.dendrogram(Colv)
     }
 
   retval$rowInd <- rowInd


### PR DESCRIPTION
The problem was that dendrograms were calculated using hclust and dist even when Rowv or Colv were set to NA, FALSE, or NULL. This made plotting large heatmaps very slow. What was the purpose of that code in the first place? And if there was a good reason for these blocks, why use hclust and not hclustfun (and dist and not distfun)?