### PR TITLE
fixed bug to pass key.title when only color key

### DIFF
--- a/R/heatmap.2.R
+++ b/R/heatmap.2.R
@@ -748,7 +748,9 @@ heatmap.2 <- function (x,
         }
       else
           if (is.null(key.title))
-              title("Color Key")
+              key.title <- "Color Key"
+          if (!is.na(key.title))
+            title(key.title)
 
       if(trace %in% c("both","column") )
           {


### PR DESCRIPTION
You could change the key.title when doing a histogram or density plot on the color key, but not when only doing the color key. I used the same code as the other two situations to allow passing of the key.title argument